### PR TITLE
Use new Martini github URL

### DIFF
--- a/example/chat.go
+++ b/example/chat.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/codegangsta/martini"
+	"github.com/go-martini/martini"
 	"github.com/martini-contrib/render"
 	"github.com/beatrichartz/martini-sockets"
 	"sync"

--- a/sockets.go
+++ b/sockets.go
@@ -15,7 +15,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/codegangsta/martini"
+	"github.com/go-martini/martini"
 	"github.com/gorilla/websocket"
 )
 

--- a/sockets_test.go
+++ b/sockets_test.go
@@ -1,7 +1,7 @@
 package sockets
 
 import (
-	"github.com/codegangsta/martini"
+	"github.com/go-martini/martini"
 	"github.com/gorilla/websocket"
 	"io"
 	"net/http"


### PR DESCRIPTION
martini-sockets is still using the old location, Martini has moved to a new URL.
